### PR TITLE
Implement Trust Badge plugin for MyListing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# Trust-Badge-addons-for-My-Listing-WordPress-Theme
+# Trust Badge Add-on for MyListing
+
+This repository contains a WordPress plugin that implements the Trust Badge workflow for the MyListing directory theme. The plugin ships with:
+
+- A custom post type to track badge requests and their lifecycle (pending, approved, rejected, expired).
+- REST API endpoints for listing owners and administrators to submit, review, approve, reject, and extend requests.
+- MyListing dashboard integrations that let listing owners request badges and copy embed codes directly from their account area.
+- Admin pages for reviewing requests and configuring global badge settings such as default validity periods, reminder timing, and allowed document MIME types.
+- A dynamic badge renderer with both script and iframe delivery options backed by a secure token.
+- Cron automation to expire badges automatically when they reach their validity limit.
+
+To install, copy the `trust-badge` directory into your WordPress installation's `wp-content/plugins/` folder and activate **Trust Badge for MyListing** from the Plugins screen.

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ This repository contains a WordPress plugin that implements the Trust Badge work
 - A dynamic badge renderer with both script and iframe delivery options backed by a secure token.
 - Cron automation to expire badges automatically when they reach their validity limit.
 
+The dashboard embed modal now surfaces both the script embed and an iframe fallback snippet, making it easy to use the badge in builders that restrict JavaScript embeds.
+
 To install, copy the `trust-badge` directory into your WordPress installation's `wp-content/plugins/` folder and activate **Trust Badge for MyListing** from the Plugins screen.

--- a/trust-badge/assets/admin.css
+++ b/trust-badge/assets/admin.css
@@ -1,0 +1,1 @@
+.tb-badge-preview { display: inline-block; margin-top: 1rem; }

--- a/trust-badge/assets/admin.js
+++ b/trust-badge/assets/admin.js
@@ -1,0 +1,9 @@
+(function($){
+    'use strict';
+
+    $(function(){
+        if ($('.tb-color-field').length){
+            $('.tb-color-field').wpColorPicker();
+        }
+    });
+})(jQuery);

--- a/trust-badge/assets/embed.js
+++ b/trust-badge/assets/embed.js
@@ -1,0 +1,36 @@
+(function(){
+    'use strict';
+    function renderBadge(container){
+        var token = container.getAttribute('data-tb-token');
+        if(!token){return;}
+        var endpoint = (window.TBTrustBadge && TBTrustBadge.endpoint) || (document.currentScript ? document.currentScript.src.replace(/\/assets\/embed\.js.*/, '') + 'wp-json/trustbadge/v1/badge/' : '');
+        if(!endpoint){
+            endpoint = window.location.origin + '/wp-json/trustbadge/v1/badge/';
+        }
+        fetch(endpoint + encodeURIComponent(token), {credentials:'omit'})
+            .then(function(res){return res.json();})
+            .then(function(data){
+                if(!data.valid){
+                    container.innerHTML = '';
+                    return;
+                }
+                container.innerHTML = data.badge;
+            })
+            .catch(function(){
+                container.innerHTML = '';
+            });
+    }
+
+    function init(){
+        var containers = document.querySelectorAll('[data-tb-token]');
+        for(var i=0;i<containers.length;i++){
+            renderBadge(containers[i]);
+        }
+    }
+
+    if(document.readyState === 'loading'){
+        document.addEventListener('DOMContentLoaded', init);
+    }else{
+        init();
+    }
+})();

--- a/trust-badge/assets/frontend.css
+++ b/trust-badge/assets/frontend.css
@@ -14,6 +14,12 @@
 .tb-actions { margin-top: 1rem; }
 .tb-response { margin-top: 0.75rem; min-height: 1.25rem; }
 .tb-embed textarea { width: 100%; height: 120px; }
+.tb-embed__group { margin-top: 1rem; }
+.tb-embed__group:first-of-type { margin-top: 0.5rem; }
+.tb-embed__group label { display: block; font-weight: 600; margin-bottom: 0.5rem; }
+.tb-embed__group .tb-copy { margin-top: 0.5rem; }
+.tb-embed__code--compact { height: 90px; }
+.tb-embed__hint { font-size: 12px; color: #6b7280; margin-top: 0.5rem; line-height: 1.4; }
 .tb-badge { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; background: #fff; border-radius: 14px; padding: 16px; border: 1px solid rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 8px; max-width: 320px; }
 .tb-badge__header { display: flex; align-items: center; gap: 8px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; }
 .tb-badge__icon { display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border-radius: 999px; color: #fff; }

--- a/trust-badge/assets/frontend.css
+++ b/trust-badge/assets/frontend.css
@@ -1,0 +1,22 @@
+#tb-modal-root.tb-hidden { display: none; }
+#tb-modal-root { position: fixed; inset: 0; z-index: 10000; }
+.tb-modal-overlay { position: absolute; inset: 0; background: rgba(17, 24, 39, 0.55); display: flex; align-items: center; justify-content: center; padding: 2rem; }
+.tb-modal { background: #fff; max-width: 480px; width: 100%; border-radius: 12px; box-shadow: 0 20px 45px rgba(0,0,0,0.18); position: relative; padding: 1.5rem; }
+.tb-modal__close { position: absolute; top: 0.5rem; right: 0.75rem; border: 0; background: transparent; font-size: 1.5rem; cursor: pointer; }
+.tb-modal__content h2 { margin-top: 0; }
+.tb-request-form label { display: block; margin-bottom: 0.75rem; font-weight: 600; }
+.tb-request-form input[type="text"],
+.tb-request-form input[type="email"] { width: 100%; padding: 0.5rem; margin-top: 0.25rem; }
+.tb-upload-list ul { list-style: none; margin: 0.5rem 0 0; padding: 0; }
+.tb-upload-list li { display: flex; justify-content: space-between; align-items: center; background: #f3f4f6; padding: 0.4rem 0.6rem; border-radius: 6px; margin-bottom: 0.35rem; }
+.tb-upload-list .tb-remove { border: 0; background: transparent; font-size: 1.25rem; line-height: 1; cursor: pointer; }
+.tb-consent { font-weight: 400; }
+.tb-actions { margin-top: 1rem; }
+.tb-response { margin-top: 0.75rem; min-height: 1.25rem; }
+.tb-embed textarea { width: 100%; height: 120px; }
+.tb-badge { font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif; background: #fff; border-radius: 14px; padding: 16px; border: 1px solid rgba(0,0,0,0.08); display: flex; flex-direction: column; gap: 8px; max-width: 320px; }
+.tb-badge__header { display: flex; align-items: center; gap: 8px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280; }
+.tb-badge__icon { display: inline-flex; align-items: center; justify-content: center; width: 36px; height: 36px; border-radius: 999px; color: #fff; }
+.tb-badge__title { font-size: 18px; font-weight: 600; color: #111827; }
+.tb-badge__status { font-size: 14px; color: #1f2937; }
+.tb-badge__link { text-decoration: none; display: inline-block; }

--- a/trust-badge/assets/frontend.js
+++ b/trust-badge/assets/frontend.js
@@ -8,6 +8,12 @@
     var restRoot = window.TBFrontend.restRoot.replace(/\/$/, '');
     var nonce    = window.TBFrontend.nonce;
     var modalRoot = document.getElementById('tb-modal-root');
+    var embedScriptUrl = window.TBFrontend.embedScript || '';
+    var iframeBase = window.TBFrontend.iframeBase || '';
+
+    if (iframeBase && iframeBase.slice(-1) !== '/') {
+        iframeBase += '/';
+    }
 
     function ensureModalRoot(){
         if (!modalRoot) {
@@ -167,8 +173,17 @@
         var container = overlay.querySelector('.tb-modal__content');
         container.innerHTML = '<h2>' + wp.i18n.__('Trust Badge Embed', 'trust-badge') + '</h2>' +
             '<div class="tb-embed"><p>' + wp.i18n.__('Use the code below to embed your live trust badge.', 'trust-badge') + '</p>' +
-            '<textarea class="tb-embed__code" readonly></textarea>' +
-            '<button type="button" class="button button-secondary tb-copy">' + window.TBFrontend.copyLabel + '</button>' +
+            '<div class="tb-embed__group">' +
+                '<label>' + wp.i18n.__('Script embed', 'trust-badge') + '</label>' +
+                '<textarea class="tb-embed__code" data-type="script" readonly></textarea>' +
+                '<button type="button" class="button button-secondary tb-copy" data-target="script">' + window.TBFrontend.copyLabel + '</button>' +
+            '</div>' +
+            '<div class="tb-embed__group">' +
+                '<label>' + wp.i18n.__('Iframe fallback', 'trust-badge') + '</label>' +
+                '<textarea class="tb-embed__code tb-embed__code--compact" data-type="iframe" readonly></textarea>' +
+                '<button type="button" class="button button-secondary tb-copy" data-target="iframe">' + wp.i18n.__('Copy iframe code', 'trust-badge') + '</button>' +
+                '<p class="tb-embed__hint">' + wp.i18n.__('Use this option if script embeds are not supported by your site builder.', 'trust-badge') + '</p>' +
+            '</div>' +
             '<div class="tb-embed__meta"></div></div>';
 
         openModal(overlay);
@@ -176,26 +191,75 @@
         fetch(restRoot + '/requests/' + options.requestId, { headers: { 'X-WP-Nonce': nonce } })
             .then(function(res){ return res.ok ? res.json() : Promise.reject(); })
             .then(function(data){
-                var textarea = container.querySelector('.tb-embed__code');
+                var scriptField = container.querySelector('.tb-embed__code[data-type="script"]');
+                var iframeField = container.querySelector('.tb-embed__code[data-type="iframe"]');
                 var token = data.token;
-                var origin = window.location.origin;
-                var snippet = '<div data-tb-token="' + token + '"></div>\n<script async src="' + origin + '/wp-content/plugins/trust-badge/assets/embed.js"></script>';
-                textarea.value = snippet;
+                var scriptUrl = embedScriptUrl || (window.location.origin + '/wp-content/plugins/trust-badge/assets/embed.js');
+                var iframeUrlBase = iframeBase || (restRoot.replace(/\/$/, '') + '/embed/');
+                var scriptSnippet = '<div class="tb-trust-badge" data-tb-token="' + token + '"></div>\n<script async src="' + scriptUrl + '"></script>';
+                var iframeSnippet = '<iframe src="' + iframeUrlBase + token + '" width="320" height="140" loading="lazy" frameborder="0" referrerpolicy="no-referrer-when-downgrade"></iframe>';
+
+                if (scriptField) {
+                    scriptField.value = scriptSnippet;
+                }
+
+                if (iframeField) {
+                    iframeField.value = iframeSnippet;
+                }
+
                 var meta = container.querySelector('.tb-embed__meta');
                 if (data.expires_at){
                     meta.textContent = wp.i18n.sprintf(wp.i18n.__('Valid until %s', 'trust-badge'), new Date(data.expires_at).toLocaleDateString());
                 }
             });
 
-        container.querySelector('.tb-copy').addEventListener('click', function(){
-            var textarea = container.querySelector('.tb-embed__code');
-            textarea.select();
-            try {
-                document.execCommand('copy');
-                this.textContent = window.TBFrontend.copiedLabel;
-            } catch (e) {
-                window.prompt('Copy code:', textarea.value);
-            }
+        container.querySelectorAll('.tb-copy').forEach(function(button){
+            button.addEventListener('click', function(){
+                var target = button.getAttribute('data-target');
+                var textarea = container.querySelector('.tb-embed__code[data-type="' + target + '"]');
+
+                if (!textarea){
+                    return;
+                }
+
+                var value = textarea.value;
+                var originalText = button.textContent;
+
+                var markCopied = function(){
+                    button.textContent = window.TBFrontend.copiedLabel;
+                    button.disabled = true;
+                    setTimeout(function(){
+                        button.textContent = originalText;
+                        button.disabled = false;
+                    }, 2000);
+                };
+
+                var promptFallback = function(){
+                    window.prompt(wp.i18n.__('Copy this code manually:', 'trust-badge'), value);
+                };
+
+                if (navigator.clipboard && navigator.clipboard.writeText){
+                    navigator.clipboard.writeText(value).then(markCopied).catch(function(){
+                        textarea.select();
+                        try {
+                            document.execCommand('copy');
+                            markCopied();
+                        } catch (err) {
+                            promptFallback();
+                        }
+                    });
+                    return;
+                }
+
+                textarea.select();
+
+                try {
+                    document.execCommand('copy');
+                    markCopied();
+                } catch (err) {
+                    promptFallback();
+                }
+            });
         });
     }
 

--- a/trust-badge/assets/frontend.js
+++ b/trust-badge/assets/frontend.js
@@ -1,0 +1,210 @@
+(function(window, document, $){
+    'use strict';
+
+    if (!window.TBFrontend) {
+        return;
+    }
+
+    var restRoot = window.TBFrontend.restRoot.replace(/\/$/, '');
+    var nonce    = window.TBFrontend.nonce;
+    var modalRoot = document.getElementById('tb-modal-root');
+
+    function ensureModalRoot(){
+        if (!modalRoot) {
+            modalRoot = document.createElement('div');
+            modalRoot.id = 'tb-modal-root';
+            modalRoot.className = 'tb-hidden';
+            document.body.appendChild(modalRoot);
+        }
+    }
+
+    function closeModal(){
+        ensureModalRoot();
+        modalRoot.innerHTML = '';
+        modalRoot.classList.add('tb-hidden');
+        modalRoot.removeAttribute('aria-hidden');
+    }
+
+    function openModal(content){
+        ensureModalRoot();
+        modalRoot.innerHTML = '';
+        modalRoot.appendChild(content);
+        modalRoot.classList.remove('tb-hidden');
+        modalRoot.setAttribute('aria-hidden', 'false');
+    }
+
+    function createOverlay(){
+        var overlay = document.createElement('div');
+        overlay.className = 'tb-modal-overlay';
+        overlay.innerHTML = '<div class="tb-modal" role="dialog" aria-modal="true"><button type="button" class="tb-modal__close" aria-label="Close">&times;</button><div class="tb-modal__content"></div></div>';
+        overlay.querySelector('.tb-modal__close').addEventListener('click', closeModal);
+        overlay.addEventListener('click', function(e){
+            if (e.target === overlay) {
+                closeModal();
+            }
+        });
+        return overlay;
+    }
+
+    function renderRequestForm(options){
+        options = options || {};
+        var overlay = createOverlay();
+        var container = overlay.querySelector('.tb-modal__content');
+        container.innerHTML = '<h2>' + (options.renew ? window.tb_i18n_renew_title || 'Renew Trust Badge' : 'Trust Badge Request') + '</h2>' +
+            '<form class="tb-request-form">' +
+            '<label>' + wp.i18n.__('Contact name', 'trust-badge') + '<input type="text" name="contact_name" required></label>' +
+            '<label>' + wp.i18n.__('Contact email', 'trust-badge') + '<input type="email" name="contact_email" required></label>' +
+            '<label>' + wp.i18n.__('Contact phone', 'trust-badge') + '<input type="text" name="contact_phone"></label>' +
+            '<div class="tb-upload-list"><strong>' + wp.i18n.__('Documents', 'trust-badge') + '</strong><ul></ul><button type="button" class="button tb-upload-button">' + wp.i18n.__('Add documents', 'trust-badge') + '</button></div>' +
+            '<label class="tb-consent"><input type="checkbox" name="consent" required> ' + wp.i18n.__('I confirm documents are accurate', 'trust-badge') + '</label>' +
+            '<div class="tb-actions"><button type="submit" class="button button-primary">' + wp.i18n.__('Submit request', 'trust-badge') + '</button></div>' +
+            '<div class="tb-response" aria-live="polite"></div>' +
+            '</form>';
+
+        var form = container.querySelector('form');
+        var docList = form.querySelector('.tb-upload-list ul');
+        var documents = [];
+
+        function renderDocuments(){
+            docList.innerHTML = '';
+            documents.forEach(function(doc){
+                var li = document.createElement('li');
+                li.innerHTML = '<span>' + doc.title + '</span> <button type="button" class="tb-remove" data-id="' + doc.id + '">&times;</button>';
+                docList.appendChild(li);
+            });
+        }
+
+        function openMedia(){
+            if (!wp.media) {
+                window.alert('Media library unavailable');
+                return;
+            }
+            var frame = wp.media({
+                title: wp.i18n.__('Select documents', 'trust-badge'),
+                multiple: true,
+                library: { type: 'application/pdf,image/jpeg,image/png,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document' }
+            });
+            frame.on('select', function(){
+                var selection = frame.state().get('selection');
+                selection.each(function(attachment){
+                    var data = attachment.toJSON();
+                    documents.push({ id: data.id, title: data.title });
+                });
+                renderDocuments();
+            });
+            frame.open();
+        }
+
+        form.querySelector('.tb-upload-button').addEventListener('click', function(e){
+            e.preventDefault();
+            openMedia();
+        });
+
+        docList.addEventListener('click', function(e){
+            if (e.target.classList.contains('tb-remove')){
+                var removeId = parseInt(e.target.getAttribute('data-id'), 10);
+                documents = documents.filter(function(doc){ return doc.id !== removeId; });
+                renderDocuments();
+            }
+        });
+
+        if (options.requestId){
+            fetch(restRoot + '/requests/' + options.requestId, { headers: { 'X-WP-Nonce': nonce } })
+                .then(function(res){ return res.ok ? res.json() : Promise.reject(); })
+                .then(function(data){
+                    form.querySelector('[name="contact_name"]').value = data.contact.name || '';
+                    form.querySelector('[name="contact_email"]').value = data.contact.email || '';
+                    form.querySelector('[name="contact_phone"]').value = data.contact.phone || '';
+                    documents = (data.documents || []).map(function(id){
+                        return { id: id, title: wp.i18n.sprintf(wp.i18n.__('Attachment #%d', 'trust-badge'), id) };
+                    });
+                    renderDocuments();
+                })
+                .catch(function(){ /* ignore */ });
+        }
+
+        form.addEventListener('submit', function(e){
+            e.preventDefault();
+            var formData = new window.FormData(form);
+            if (!formData.get('consent')){
+                window.alert(wp.i18n.__('You must consent before submitting.', 'trust-badge'));
+                return;
+            }
+            var payload = {
+                listing_id: options.listingId,
+                contact_name: formData.get('contact_name'),
+                contact_email: formData.get('contact_email'),
+                contact_phone: formData.get('contact_phone'),
+                documents: documents.map(function(doc){ return doc.id; })
+            };
+            fetch(restRoot + '/requests', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': nonce
+                },
+                body: JSON.stringify(payload)
+            }).then(function(res){
+                if (!res.ok){
+                    return res.json().then(function(error){ throw error; });
+                }
+                return res.json();
+            }).then(function(){
+                form.querySelector('.tb-response').textContent = wp.i18n.__('Request submitted successfully.', 'trust-badge');
+                setTimeout(closeModal, 1500);
+            }).catch(function(error){
+                var message = (error && error.message) ? error.message : wp.i18n.__('Unable to submit request.', 'trust-badge');
+                form.querySelector('.tb-response').textContent = message;
+            });
+        });
+
+        openModal(overlay);
+        form.querySelector('[name="contact_name"]').focus();
+    }
+
+    function renderEmbedModal(options){
+        var overlay = createOverlay();
+        var container = overlay.querySelector('.tb-modal__content');
+        container.innerHTML = '<h2>' + wp.i18n.__('Trust Badge Embed', 'trust-badge') + '</h2>' +
+            '<div class="tb-embed"><p>' + wp.i18n.__('Use the code below to embed your live trust badge.', 'trust-badge') + '</p>' +
+            '<textarea class="tb-embed__code" readonly></textarea>' +
+            '<button type="button" class="button button-secondary tb-copy">' + window.TBFrontend.copyLabel + '</button>' +
+            '<div class="tb-embed__meta"></div></div>';
+
+        openModal(overlay);
+
+        fetch(restRoot + '/requests/' + options.requestId, { headers: { 'X-WP-Nonce': nonce } })
+            .then(function(res){ return res.ok ? res.json() : Promise.reject(); })
+            .then(function(data){
+                var textarea = container.querySelector('.tb-embed__code');
+                var token = data.token;
+                var origin = window.location.origin;
+                var snippet = '<div data-tb-token="' + token + '"></div>\n<script async src="' + origin + '/wp-content/plugins/trust-badge/assets/embed.js"></script>';
+                textarea.value = snippet;
+                var meta = container.querySelector('.tb-embed__meta');
+                if (data.expires_at){
+                    meta.textContent = wp.i18n.sprintf(wp.i18n.__('Valid until %s', 'trust-badge'), new Date(data.expires_at).toLocaleDateString());
+                }
+            });
+
+        container.querySelector('.tb-copy').addEventListener('click', function(){
+            var textarea = container.querySelector('.tb-embed__code');
+            textarea.select();
+            try {
+                document.execCommand('copy');
+                this.textContent = window.TBFrontend.copiedLabel;
+            } catch (e) {
+                window.prompt('Copy code:', textarea.value);
+            }
+        });
+    }
+
+    window.tbOpenRequest = function(args){
+        renderRequestForm(args || {});
+    };
+
+    window.tbOpenEmbed = function(args){
+        renderEmbedModal(args || {});
+    };
+
+})(window, document, window.jQuery || {});

--- a/trust-badge/assets/frontend.js
+++ b/trust-badge/assets/frontend.js
@@ -199,6 +199,46 @@
         });
     }
 
+    document.addEventListener('click', function(event){
+        var trigger = event.target.closest('a.tb-listing-action');
+
+        if (!trigger){
+            return;
+        }
+
+        var dataset = trigger.dataset || {};
+        var actionType = dataset.tbAction;
+
+        if (!actionType){
+            return;
+        }
+
+        event.preventDefault();
+
+        var args = {};
+
+        if (dataset.listingId){
+            args.listingId = parseInt(dataset.listingId, 10);
+        }
+
+        if (dataset.requestId){
+            args.requestId = parseInt(dataset.requestId, 10);
+        }
+
+        if (dataset.tbRenew){
+            args.renew = dataset.tbRenew !== '0';
+        }
+
+        if (actionType === 'request'){
+            renderRequestForm(args);
+            return;
+        }
+
+        if (actionType === 'embed' && args.requestId){
+            renderEmbedModal(args);
+        }
+    });
+
     window.tbOpenRequest = function(args){
         renderRequestForm(args || {});
     };

--- a/trust-badge/includes/class-tb-admin.php
+++ b/trust-badge/includes/class-tb-admin.php
@@ -1,0 +1,400 @@
+<?php
+/**
+ * Admin UI and menus.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Admin {
+
+    /**
+     * Hook registration.
+     */
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'register_menu' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_assets' ] );
+        add_action( 'admin_post_tb_approve_request', [ __CLASS__, 'handle_approve_request' ] );
+        add_action( 'admin_post_tb_reject_request', [ __CLASS__, 'handle_reject_request' ] );
+        add_action( 'admin_post_tb_extend_request', [ __CLASS__, 'handle_extend_request' ] );
+        add_action( 'admin_post_tb_revoke_request', [ __CLASS__, 'handle_revoke_request' ] );
+    }
+
+    /**
+     * Register admin menu pages.
+     */
+    public static function register_menu() {
+        add_menu_page(
+            __( 'Trust Badges', 'trust-badge' ),
+            __( 'Trust Badges', 'trust-badge' ),
+            'manage_options',
+            'tb_requests',
+            [ __CLASS__, 'render_requests_page' ],
+            'dashicons-awards',
+            58
+        );
+
+        add_submenu_page(
+            'tb_requests',
+            __( 'Requests', 'trust-badge' ),
+            __( 'Requests', 'trust-badge' ),
+            'manage_options',
+            'tb_requests',
+            [ __CLASS__, 'render_requests_page' ]
+        );
+
+        add_submenu_page(
+            'tb_requests',
+            __( 'Settings', 'trust-badge' ),
+            __( 'Settings', 'trust-badge' ),
+            'manage_options',
+            'tb_settings',
+            [ __CLASS__, 'render_settings_page' ]
+        );
+
+        add_submenu_page(
+            null,
+            __( 'Trust Badge Request Detail', 'trust-badge' ),
+            __( 'Trust Badge Request Detail', 'trust-badge' ),
+            'manage_options',
+            'tb_request_detail',
+            [ __CLASS__, 'render_request_detail_page' ]
+        );
+    }
+
+    /**
+     * Enqueue admin assets.
+     */
+    public static function enqueue_admin_assets( $hook ) {
+        if ( false === strpos( $hook, 'tb_' ) ) {
+            return;
+        }
+
+        wp_enqueue_style( 'tb-admin', TB_PLUGIN_URL . 'assets/admin.css', [], TB_PLUGIN_VER );
+        wp_enqueue_style( 'wp-color-picker' );
+        wp_enqueue_script( 'tb-admin', TB_PLUGIN_URL . 'assets/admin.js', [ 'jquery', 'wp-color-picker' ], TB_PLUGIN_VER, true );
+    }
+
+    /**
+     * Render requests admin page.
+     */
+    public static function render_requests_page() {
+        if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_trust_badges' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'trust-badge' ) );
+        }
+
+        $status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+        $query  = new WP_Query( [
+            'post_type'      => TB_CPT::POST_TYPE,
+            'post_status'    => $status ? [ $status ] : [ 'tb_pending', 'tb_approved', 'tb_rejected', 'tb_expired' ],
+            'posts_per_page' => 20,
+            'paged'          => max( 1, absint( $_GET['paged'] ?? 1 ) ), // phpcs:ignore WordPress.Security.NonceVerification
+        ] );
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Trust Badge Requests', 'trust-badge' ) . '</h1>';
+
+        echo '<form method="get">';
+        echo '<input type="hidden" name="page" value="tb_requests" />';
+        echo '<label for="tb-status-filter" class="screen-reader-text">' . esc_html__( 'Filter by status', 'trust-badge' ) . '</label>';
+        echo '<select id="tb-status-filter" name="status">';
+        echo '<option value="">' . esc_html__( 'All statuses', 'trust-badge' ) . '</option>';
+        foreach ( [ 'tb_pending', 'tb_approved', 'tb_rejected', 'tb_expired' ] as $slug ) {
+            printf( '<option value="%1$s" %2$s>%3$s</option>', esc_attr( $slug ), selected( $status, $slug, false ), esc_html( TB_CPT::get_status_label( $slug ) ) );
+        }
+        echo '</select> ';
+        submit_button( __( 'Filter', 'trust-badge' ), 'secondary', '', false );
+        echo '</form>';
+
+        echo '<table class="widefat fixed striped">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__( 'Listing', 'trust-badge' ) . '</th>';
+        echo '<th>' . esc_html__( 'Owner', 'trust-badge' ) . '</th>';
+        echo '<th>' . esc_html__( 'Status', 'trust-badge' ) . '</th>';
+        echo '<th>' . esc_html__( 'Submitted', 'trust-badge' ) . '</th>';
+        echo '<th>' . esc_html__( 'Expires', 'trust-badge' ) . '</th>';
+        echo '<th>' . esc_html__( 'Actions', 'trust-badge' ) . '</th>';
+        echo '</tr></thead><tbody>';
+
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
+                $query->the_post();
+                $request_id = get_the_ID();
+                $listing_id = (int) get_post_field( 'post_parent', $request_id );
+                $owner_id   = (int) get_post_field( 'post_author', $request_id );
+                $expires    = (int) get_post_meta( $request_id, TB_Request::META_EXPIRES_AT, true );
+
+                echo '<tr>';
+                echo '<td>';
+                if ( $listing_id ) {
+                    echo '<a href="' . esc_url( get_edit_post_link( $listing_id ) ) . '">' . esc_html( get_the_title( $listing_id ) ) . '</a>';
+                } else {
+                    esc_html_e( '—', 'trust-badge' );
+                }
+                echo '</td>';
+
+                echo '<td>';
+                if ( $owner_id ) {
+                    $user = get_userdata( $owner_id );
+                    if ( $user ) {
+                        echo '<a href="' . esc_url( get_edit_user_link( $owner_id ) ) . '">' . esc_html( $user->display_name ) . '</a>';
+                    }
+                }
+                echo '</td>';
+
+                echo '<td>' . esc_html( TB_CPT::get_status_label( get_post_status( $request_id ) ) ) . '</td>';
+                echo '<td>' . esc_html( get_the_date() ) . '</td>';
+                echo '<td>' . ( $expires ? esc_html( date_i18n( get_option( 'date_format' ), $expires ) ) : '—' ) . '</td>';
+                echo '<td><a class="button" href="' . esc_url( add_query_arg( [ 'page' => 'tb_request_detail', 'request_id' => $request_id ], admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View', 'trust-badge' ) . '</a></td>';
+                echo '</tr>';
+            }
+            wp_reset_postdata();
+        } else {
+            echo '<tr><td colspan="6">' . esc_html__( 'No requests found.', 'trust-badge' ) . '</td></tr>';
+        }
+
+        echo '</tbody></table>';
+
+        $big = 999999999;
+        $pagination = paginate_links( [
+            'base'      => str_replace( $big, '%#%', esc_url( add_query_arg( 'paged', $big ) ) ),
+            'format'    => '',
+            'current'   => max( 1, (int) ( $_GET['paged'] ?? 1 ) ), // phpcs:ignore WordPress.Security.NonceVerification
+            'total'     => (int) $query->max_num_pages,
+            'type'      => 'array',
+            'add_args'  => [ 'status' => $status ],
+        ] );
+
+        if ( $pagination ) {
+            echo '<div class="tablenav"><div class="tablenav-pages">' . join( '', array_map( 'wp_kses_post', $pagination ) ) . '</div></div>';
+        }
+
+        echo '</div>';
+    }
+
+    /**
+     * Render settings page.
+     */
+    public static function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'trust-badge' ) );
+        }
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Trust Badge Settings', 'trust-badge' ) . '</h1>';
+        echo '<form method="post" action="options.php">';
+        settings_fields( 'tb_settings' );
+        do_settings_sections( 'tb_settings' );
+        submit_button();
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Render single request detail page.
+     */
+    public static function render_request_detail_page() {
+        if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'manage_trust_badges' ) ) {
+            wp_die( esc_html__( 'You do not have permission to access this page.', 'trust-badge' ) );
+        }
+
+        $request_id = isset( $_GET['request_id'] ) ? absint( $_GET['request_id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification
+        $post       = $request_id ? get_post( $request_id ) : null;
+
+        if ( ! $post || TB_CPT::POST_TYPE !== $post->post_type ) {
+            wp_die( esc_html__( 'Request not found.', 'trust-badge' ) );
+        }
+
+        $listing_id = (int) $post->post_parent;
+        $owner_id   = (int) $post->post_author;
+        $owner      = $owner_id ? get_userdata( $owner_id ) : null;
+        $expires    = (int) get_post_meta( $post->ID, TB_Request::META_EXPIRES_AT, true );
+        $documents  = (array) get_post_meta( $post->ID, TB_Request::META_DOCUMENTS, true );
+        $status     = get_post_status( $post );
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Trust Badge Request Detail', 'trust-badge' ) . '</h1>';
+
+        echo '<table class="widefat fixed">';
+        echo '<tbody>';
+        echo '<tr><th>' . esc_html__( 'Listing', 'trust-badge' ) . '</th><td>' . ( $listing_id ? '<a href="' . esc_url( get_edit_post_link( $listing_id ) ) . '">' . esc_html( get_the_title( $listing_id ) ) . '</a>' : '—' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Owner', 'trust-badge' ) . '</th><td>' . ( $owner ? '<a href="' . esc_url( get_edit_user_link( $owner_id ) ) . '">' . esc_html( $owner->display_name ) . '</a>' : '—' ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Contact name', 'trust-badge' ) . '</th><td>' . esc_html( get_post_meta( $post->ID, TB_Request::META_CONTACT_NAME, true ) ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Contact email', 'trust-badge' ) . '</th><td><a href="mailto:' . esc_attr( get_post_meta( $post->ID, TB_Request::META_CONTACT_EMAIL, true ) ) . '">' . esc_html( get_post_meta( $post->ID, TB_Request::META_CONTACT_EMAIL, true ) ) . '</a></td></tr>';
+        echo '<tr><th>' . esc_html__( 'Contact phone', 'trust-badge' ) . '</th><td>' . esc_html( get_post_meta( $post->ID, TB_Request::META_CONTACT_PHONE, true ) ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Status', 'trust-badge' ) . '</th><td>' . esc_html( TB_CPT::get_status_label( $status ) ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Submitted', 'trust-badge' ) . '</th><td>' . esc_html( get_the_date( '', $post ) ) . '</td></tr>';
+        echo '<tr><th>' . esc_html__( 'Expires', 'trust-badge' ) . '</th><td>' . ( $expires ? esc_html( date_i18n( get_option( 'date_format' ), $expires ) ) : '—' ) . '</td></tr>';
+        echo '</tbody>';
+        echo '</table>';
+
+        echo '<h2>' . esc_html__( 'Documents', 'trust-badge' ) . '</h2>';
+        if ( $documents ) {
+            echo '<ul class="tb-documents">';
+            foreach ( $documents as $doc_id ) {
+                $url   = wp_get_attachment_url( $doc_id );
+                $title = get_the_title( $doc_id );
+                $title = $title ? $title : sprintf( __( 'Document #%d', 'trust-badge' ), (int) $doc_id );
+                if ( $url ) {
+                    echo '<li><a href="' . esc_url( $url ) . '" target="_blank" rel="nofollow noopener">' . esc_html( $title ) . '</a></li>';
+                } else {
+                    echo '<li>' . esc_html( $title ) . '</li>';
+                }
+            }
+            echo '</ul>';
+        } else {
+            echo '<p>' . esc_html__( 'No documents uploaded.', 'trust-badge' ) . '</p>';
+        }
+
+        echo '<h2>' . esc_html__( 'Actions', 'trust-badge' ) . '</h2>';
+
+        echo '<div class="tb-admin-actions">';
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="tb-approve-form">';
+        wp_nonce_field( 'tb_approve_request' );
+        echo '<input type="hidden" name="action" value="tb_approve_request" />';
+        echo '<input type="hidden" name="request_id" value="' . esc_attr( $post->ID ) . '" />';
+        echo '<label>' . esc_html__( 'Expiry date', 'trust-badge' ) . '<input type="date" name="expires_at" value="' . ( $expires ? esc_attr( gmdate( 'Y-m-d', $expires ) ) : '' ) . '" required /></label> ';
+        echo '<label>' . esc_html__( 'Note (optional)', 'trust-badge' ) . '<input type="text" name="note" /></label> ';
+        submit_button( __( 'Approve', 'trust-badge' ), 'primary', '', false );
+        echo '</form>';
+
+        echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="tb-reject-form">';
+        wp_nonce_field( 'tb_reject_request' );
+        echo '<input type="hidden" name="action" value="tb_reject_request" />';
+        echo '<input type="hidden" name="request_id" value="' . esc_attr( $post->ID ) . '" />';
+        echo '<label>' . esc_html__( 'Rejection note', 'trust-badge' ) . '<input type="text" name="note" required /></label> ';
+        submit_button( __( 'Reject', 'trust-badge' ), 'secondary', '', false );
+        echo '</form>';
+
+        if ( 'tb_approved' === $status ) {
+            echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="tb-extend-form">';
+            wp_nonce_field( 'tb_extend_request' );
+            echo '<input type="hidden" name="action" value="tb_extend_request" />';
+            echo '<input type="hidden" name="request_id" value="' . esc_attr( $post->ID ) . '" />';
+            echo '<label>' . esc_html__( 'New expiry date', 'trust-badge' ) . '<input type="date" name="expires_at" value="' . ( $expires ? esc_attr( gmdate( 'Y-m-d', $expires ) ) : '' ) . '" required /></label> ';
+            submit_button( __( 'Extend', 'trust-badge' ), 'secondary', '', false );
+            echo '</form>';
+
+            echo '<form method="post" action="' . esc_url( admin_url( 'admin-post.php' ) ) . '" class="tb-revoke-form">';
+            wp_nonce_field( 'tb_revoke_request' );
+            echo '<input type="hidden" name="action" value="tb_revoke_request" />';
+            echo '<input type="hidden" name="request_id" value="' . esc_attr( $post->ID ) . '" />';
+            submit_button( __( 'Revoke Badge', 'trust-badge' ), 'delete', '', false );
+            echo '</form>';
+        }
+
+        echo '</div>';
+
+        echo '<h2>' . esc_html__( 'Audit Log', 'trust-badge' ) . '</h2>';
+        $log = TB_Request::get_audit_log( $post->ID );
+        if ( $log ) {
+            echo '<ul class="tb-audit-log">';
+            foreach ( $log as $entry ) {
+                $actor = $entry['actor'] ? get_userdata( $entry['actor'] ) : null;
+                echo '<li>' . esc_html( $entry['time'] ) . ' — ' . esc_html( $entry['action'] ) . ( $actor ? ' (' . esc_html( $actor->display_name ) . ')' : '' ) . ( $entry['note'] ? ': ' . esc_html( $entry['note'] ) : '' ) . '</li>';
+            }
+            echo '</ul>';
+        } else {
+            echo '<p>' . esc_html__( 'No activity recorded yet.', 'trust-badge' ) . '</p>';
+        }
+
+        echo '</div>';
+    }
+
+    /**
+     * Handle approve submission.
+     */
+    public static function handle_approve_request() {
+        self::verify_admin_action( 'tb_approve_request' );
+
+        $request_id = absint( $_POST['request_id'] ?? 0 );
+        $expires    = strtotime( sanitize_text_field( wp_unslash( $_POST['expires_at'] ?? '' ) ) );
+        $note       = sanitize_text_field( wp_unslash( $_POST['note'] ?? '' ) );
+
+        if ( ! $request_id || ! $expires ) {
+            wp_die( esc_html__( 'Invalid data supplied.', 'trust-badge' ) );
+        }
+
+        wp_update_post( [ 'ID' => $request_id, 'post_status' => 'tb_approved' ] );
+        TB_Request::update_meta( $request_id, [ TB_Request::META_EXPIRES_AT => $expires, TB_Request::META_DECISION_NOTE => $note ] );
+        TB_Request::log_action( $request_id, 'approved', $note );
+
+        wp_safe_redirect( add_query_arg( [ 'page' => 'tb_request_detail', 'request_id' => $request_id, 'updated' => 'approved' ], admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Handle rejection.
+     */
+    public static function handle_reject_request() {
+        self::verify_admin_action( 'tb_reject_request' );
+
+        $request_id = absint( $_POST['request_id'] ?? 0 );
+        $note       = sanitize_text_field( wp_unslash( $_POST['note'] ?? '' ) );
+
+        if ( ! $request_id || empty( $note ) ) {
+            wp_die( esc_html__( 'A rejection note is required.', 'trust-badge' ) );
+        }
+
+        wp_update_post( [ 'ID' => $request_id, 'post_status' => 'tb_rejected' ] );
+        TB_Request::update_meta( $request_id, [ TB_Request::META_DECISION_NOTE => $note ] );
+        TB_Request::log_action( $request_id, 'rejected', $note );
+
+        wp_safe_redirect( add_query_arg( [ 'page' => 'tb_request_detail', 'request_id' => $request_id, 'updated' => 'rejected' ], admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Handle extend submission.
+     */
+    public static function handle_extend_request() {
+        self::verify_admin_action( 'tb_extend_request' );
+
+        $request_id = absint( $_POST['request_id'] ?? 0 );
+        $expires    = strtotime( sanitize_text_field( wp_unslash( $_POST['expires_at'] ?? '' ) ) );
+
+        if ( ! $request_id || ! $expires ) {
+            wp_die( esc_html__( 'Invalid data supplied.', 'trust-badge' ) );
+        }
+
+        TB_Request::update_meta( $request_id, [ TB_Request::META_EXPIRES_AT => $expires ] );
+        TB_Request::log_action( $request_id, 'extended' );
+
+        wp_safe_redirect( add_query_arg( [ 'page' => 'tb_request_detail', 'request_id' => $request_id, 'updated' => 'extended' ], admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Handle revoke submission.
+     */
+    public static function handle_revoke_request() {
+        self::verify_admin_action( 'tb_revoke_request' );
+
+        $request_id = absint( $_POST['request_id'] ?? 0 );
+        if ( ! $request_id ) {
+            wp_die( esc_html__( 'Invalid data supplied.', 'trust-badge' ) );
+        }
+
+        wp_update_post( [ 'ID' => $request_id, 'post_status' => 'tb_expired' ] );
+        TB_Request::log_action( $request_id, 'revoked' );
+
+        wp_safe_redirect( add_query_arg( [ 'page' => 'tb_request_detail', 'request_id' => $request_id, 'updated' => 'revoked' ], admin_url( 'admin.php' ) ) );
+        exit;
+    }
+
+    /**
+     * Verify nonce and permissions.
+     *
+     * @param string $action Action.
+     */
+    protected static function verify_admin_action( $action ) {
+        if ( ! ( current_user_can( 'manage_options' ) || current_user_can( 'manage_trust_badges' ) ) ) {
+            wp_die( esc_html__( 'Insufficient permissions.', 'trust-badge' ) );
+        }
+
+        check_admin_referer( $action );
+    }
+}

--- a/trust-badge/includes/class-tb-autoloader.php
+++ b/trust-badge/includes/class-tb-autoloader.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Simple PSR-4 style autoloader for plugin classes.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Autoloader {
+
+    /**
+     * Namespace prefix.
+     *
+     * @var string
+     */
+    protected static $prefix = 'TB_';
+
+    /**
+     * Initialise the autoloader.
+     */
+    public static function init() {
+        spl_autoload_register( [ __CLASS__, 'autoload' ] );
+    }
+
+    /**
+     * Autoload callback.
+     *
+     * @param string $class Class name.
+     */
+    protected static function autoload( $class ) {
+        if ( 0 !== strpos( $class, self::$prefix ) ) {
+            return;
+        }
+
+        $filename = strtolower( str_replace( '_', '-', $class ) );
+        $path     = TB_PLUGIN_DIR . 'includes/class-' . $filename . '.php';
+
+        if ( file_exists( $path ) ) {
+            require_once $path;
+        }
+    }
+}

--- a/trust-badge/includes/class-tb-badge.php
+++ b/trust-badge/includes/class-tb-badge.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Badge rendering helpers.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Badge {
+
+    /**
+     * Initialise hooks.
+     */
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register_shortcode' ] );
+    }
+
+    /**
+     * Register badge shortcode for previews.
+     */
+    public static function register_shortcode() {
+        add_shortcode( 'trust_badge_preview', [ __CLASS__, 'shortcode' ] );
+    }
+
+    /**
+     * Shortcode handler.
+     */
+    public static function shortcode( $atts ) {
+        $atts = shortcode_atts( [ 'request_id' => 0 ], $atts, 'trust_badge_preview' );
+        $request_id = (int) $atts['request_id'];
+        if ( ! $request_id ) {
+            return '';
+        }
+
+        $post = get_post( $request_id );
+        if ( ! $post ) {
+            return '';
+        }
+
+        return self::generate_markup( [
+            'listing'     => get_post( $post->post_parent ),
+            'expires_at'  => (int) get_post_meta( $post->ID, TB_Request::META_EXPIRES_AT, true ),
+            'valid'       => TB_Request::is_active( $post->ID ),
+            'accent'      => TB_Settings::get_settings()['accent_color'],
+            'show_expiry' => TB_Settings::get_settings()['show_expiry'],
+            'link'        => TB_Settings::get_settings()['link_behavior'],
+        ] );
+    }
+
+    /**
+     * Generate badge markup.
+     *
+     * @param array $context Context.
+     * @return string
+     */
+    public static function generate_markup( array $context ) {
+        $listing    = $context['listing'] ?? null;
+        $valid      = ! empty( $context['valid'] );
+        $expires_at = isset( $context['expires_at'] ) ? (int) $context['expires_at'] : 0;
+        $accent     = $context['accent'] ?? '#1e73be';
+        $show_expiry = ! empty( $context['show_expiry'] );
+        $link_type  = $context['link'] ?? 'listing';
+
+        $listing_name = $listing ? $listing->post_title : __( 'Verified Listing', 'trust-badge' );
+        $issuer       = wp_parse_url( home_url(), PHP_URL_HOST );
+
+        $expires_text = $show_expiry && $expires_at
+            ? sprintf( __( 'Valid until %s', 'trust-badge' ), date_i18n( get_option( 'date_format' ), $expires_at ) )
+            : __( 'Verified listing', 'trust-badge' );
+
+        $status_text = $valid ? __( 'Verified', 'trust-badge' ) : __( 'Expired', 'trust-badge' );
+
+        $content  = '<div class="tb-badge" role="img" aria-label="' . esc_attr( $status_text ) . '">';
+        $content .= '<div class="tb-badge__header">';
+        $content .= '<span class="tb-badge__icon" style="background:' . esc_attr( $accent ) . '"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M6.173 13.777a1 1 0 0 0 .994.11l1.5-.643 1.5.643a1 1 0 0 0 .994-.11l1.286-.964 1.57-.505a1 1 0 0 0 .68-.948l.047-1.647.8-1.469a1 1 0 0 0-.096-1.066l-.997-1.312-.366-1.592a1 1 0 0 0-.77-.757l-1.6-.343-1.193-1.081a1 1 0 0 0-1.103-.152L8 1.4l-1.147-.606a1 1 0 0 0-1.103.152L4.557 2.027l-1.6.343a1 1 0 0 0-.77.757l-.366 1.592-.997 1.312a1 1 0 0 0-.096 1.066l.8 1.469.047 1.647a1 1 0 0 0 .68.948l1.57.505 1.286.964Z"/><path fill="#fff" d="M7.333 10.943 4.89 8.5l1.179-1.179 1.264 1.263 2.598-2.597L11.11 7.166l-3.11 3.11-.667.667Z"/></svg></span>';
+        $content .= '<span class="tb-badge__issuer">' . esc_html( $issuer ) . '</span>';
+        $content .= '</div>';
+        $content .= '<div class="tb-badge__body">';
+        $content .= '<div class="tb-badge__title">' . esc_html( $listing_name ) . '</div>';
+        $content .= '<div class="tb-badge__status">' . esc_html( $expires_text ) . '</div>';
+        $content .= '</div>';
+        $content .= '</div>';
+
+        if ( $valid ) {
+            $url = '';
+            if ( 'listing' === $link_type && $listing ) {
+                $url = get_permalink( $listing );
+            } elseif ( 'issuer' === $link_type ) {
+                $url = home_url();
+            }
+
+            if ( $url ) {
+                $content = '<a class="tb-badge__link" href="' . esc_url( $url ) . '" target="_blank" rel="nofollow noopener">' . $content . '</a>';
+            }
+        }
+
+        return $content;
+    }
+}

--- a/trust-badge/includes/class-tb-cpt.php
+++ b/trust-badge/includes/class-tb-cpt.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Register custom post type and statuses.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_CPT {
+
+    const POST_TYPE = 'trust_badge_request';
+
+    /**
+     * Init hooks.
+     */
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+        add_action( 'init', [ __CLASS__, 'register_statuses' ] );
+        add_filter( 'manage_edit-' . self::POST_TYPE . '_columns', [ __CLASS__, 'register_columns' ] );
+        add_action( 'manage_' . self::POST_TYPE . '_posts_custom_column', [ __CLASS__, 'render_columns' ], 10, 2 );
+        add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
+    }
+
+    /**
+     * Register CPT.
+     */
+    public static function register_post_type() {
+        $labels = [
+            'name'               => __( 'Trust Badge Requests', 'trust-badge' ),
+            'singular_name'      => __( 'Trust Badge Request', 'trust-badge' ),
+            'menu_name'          => __( 'Trust Badges', 'trust-badge' ),
+            'add_new'            => __( 'Add New', 'trust-badge' ),
+            'add_new_item'       => __( 'Add New Request', 'trust-badge' ),
+            'edit_item'          => __( 'Edit Request', 'trust-badge' ),
+            'new_item'           => __( 'New Request', 'trust-badge' ),
+            'view_item'          => __( 'View Request', 'trust-badge' ),
+            'search_items'       => __( 'Search Requests', 'trust-badge' ),
+            'not_found'          => __( 'No requests found.', 'trust-badge' ),
+            'not_found_in_trash' => __( 'No requests found in Trash.', 'trust-badge' ),
+        ];
+
+        register_post_type( self::POST_TYPE, [
+            'labels'        => $labels,
+            'public'        => false,
+            'show_ui'       => true,
+            'menu_icon'     => 'dashicons-awards',
+            'supports'      => [ 'title', 'author' ],
+            'capability_type' => [ 'trust_badge_request', 'trust_badge_requests' ],
+            'map_meta_cap'  => true,
+            'show_in_rest'  => false,
+        ] );
+    }
+
+    /**
+     * Register custom statuses.
+     */
+    public static function register_statuses() {
+        $statuses = [
+            'tb_pending' => [ 'label' => __( 'Pending', 'trust-badge' ), 'color' => '#dba617' ],
+            'tb_approved' => [ 'label' => __( 'Approved', 'trust-badge' ), 'color' => '#2d9d59' ],
+            'tb_rejected' => [ 'label' => __( 'Rejected', 'trust-badge' ), 'color' => '#c0392b' ],
+            'tb_expired' => [ 'label' => __( 'Expired', 'trust-badge' ), 'color' => '#7f8c8d' ],
+        ];
+
+        foreach ( $statuses as $key => $status ) {
+            register_post_status( $key, [
+                'label'                     => $status['label'],
+                'public'                    => false,
+                'exclude_from_search'       => true,
+                'internal'                  => true,
+                'show_in_admin_all_list'    => true,
+                'show_in_admin_status_list' => true,
+                'label_count'               => _n_noop( $status['label'] . ' <span class="count">(%s)</span>', $status['label'] . ' <span class="count">(%s)</span>', 'trust-badge' ),
+            ] );
+        }
+    }
+
+    /**
+     * Adjust columns.
+     */
+    public static function register_columns( $columns ) {
+        $new = [
+            'cb'        => $columns['cb'] ?? '',
+            'title'     => __( 'Request', 'trust-badge' ),
+            'listing'   => __( 'Listing', 'trust-badge' ),
+            'owner'     => __( 'Owner', 'trust-badge' ),
+            'status'    => __( 'Status', 'trust-badge' ),
+            'expires'   => __( 'Expires', 'trust-badge' ),
+            'date'      => $columns['date'] ?? __( 'Date', 'trust-badge' ),
+        ];
+
+        return $new;
+    }
+
+    /**
+     * Render column content.
+     */
+    public static function render_columns( $column, $post_id ) {
+        switch ( $column ) {
+            case 'listing':
+                $listing_id = get_post_field( 'post_parent', $post_id );
+                if ( $listing_id ) {
+                    $title = get_the_title( $listing_id );
+                    printf( '<a href="%1$s">%2$s</a>', esc_url( get_edit_post_link( $listing_id ) ), esc_html( $title ) );
+                } else {
+                    esc_html_e( 'N/A', 'trust-badge' );
+                }
+                break;
+            case 'owner':
+                $author = get_post_field( 'post_author', $post_id );
+                if ( $author ) {
+                    $user = get_userdata( $author );
+                    if ( $user ) {
+                        printf( '<a href="%1$s">%2$s</a>', esc_url( get_edit_user_link( $author ) ), esc_html( $user->display_name ) );
+                    }
+                }
+                break;
+            case 'status':
+                $status = get_post_status( $post_id );
+                echo esc_html( self::get_status_label( $status ) );
+                break;
+            case 'expires':
+                $expires = (int) get_post_meta( $post_id, '_tb_expires_at', true );
+                if ( $expires ) {
+                    echo esc_html( date_i18n( get_option( 'date_format' ), $expires ) );
+                } else {
+                    esc_html_e( '—', 'trust-badge' );
+                }
+                break;
+        }
+    }
+
+    /**
+     * Show custom status label in row states.
+     */
+    public static function display_post_states( $states, $post ) {
+        if ( self::POST_TYPE !== $post->post_type ) {
+            return $states;
+        }
+
+        $status = get_post_status( $post );
+        $label  = self::get_status_label( $status );
+
+        if ( $label ) {
+            $states[] = $label;
+        }
+
+        return $states;
+    }
+
+    /**
+     * Human readable status label.
+     *
+     * @param string $status Status key.
+     * @return string
+     */
+    public static function get_status_label( $status ) {
+        switch ( $status ) {
+            case 'tb_pending':
+                return __( 'Pending', 'trust-badge' );
+            case 'tb_approved':
+                return __( 'Approved', 'trust-badge' );
+            case 'tb_rejected':
+                return __( 'Rejected', 'trust-badge' );
+            case 'tb_expired':
+                return __( 'Expired', 'trust-badge' );
+            default:
+                return '';
+        }
+    }
+}

--- a/trust-badge/includes/class-tb-cron.php
+++ b/trust-badge/includes/class-tb-cron.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Cron tasks for Trust Badge.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Cron {
+
+    const HOOK_EXPIRE = 'tb_expire_badges';
+
+    /**
+     * Hook registration.
+     */
+    public static function init() {
+        add_action( self::HOOK_EXPIRE, [ __CLASS__, 'expire_badges' ] );
+    }
+
+    /**
+     * Schedule cron on activation.
+     */
+    public static function activate() {
+        if ( ! wp_next_scheduled( self::HOOK_EXPIRE ) ) {
+            wp_schedule_event( time() + HOUR_IN_SECONDS, 'twicedaily', self::HOOK_EXPIRE );
+        }
+    }
+
+    /**
+     * Clear cron on deactivation.
+     */
+    public static function deactivate() {
+        $timestamp = wp_next_scheduled( self::HOOK_EXPIRE );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, self::HOOK_EXPIRE );
+        }
+    }
+
+    /**
+     * Expire badges that reached end of life.
+     */
+    public static function expire_badges() {
+        $now = time();
+        $query = new WP_Query( [
+            'post_type'      => TB_CPT::POST_TYPE,
+            'post_status'    => 'tb_approved',
+            'posts_per_page' => 200,
+            'fields'         => 'ids',
+            'meta_query'     => [
+                [
+                    'key'     => TB_Request::META_EXPIRES_AT,
+                    'value'   => $now,
+                    'compare' => '<=',
+                    'type'    => 'NUMERIC',
+                ],
+            ],
+        ] );
+
+        if ( ! $query->posts ) {
+            return;
+        }
+
+        foreach ( $query->posts as $request_id ) {
+            wp_update_post( [ 'ID' => $request_id, 'post_status' => 'tb_expired' ] );
+            TB_Request::log_action( $request_id, 'expired' );
+            do_action( 'tb_request_expired', $request_id );
+        }
+    }
+}

--- a/trust-badge/includes/class-tb-frontend.php
+++ b/trust-badge/includes/class-tb-frontend.php
@@ -17,6 +17,8 @@ class TB_Frontend {
     public static function init() {
         add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
         add_filter( 'mylisting/listing_actions', [ __CLASS__, 'inject_listing_actions' ], 10, 2 );
+        add_action( 'mylisting/user-listings/actions', [ __CLASS__, 'render_dashboard_action' ], 20 );
+        add_action( 'mylisting/dashboard/listing-actions', [ __CLASS__, 'render_dashboard_action' ], 20 );
         add_action( 'wp_footer', [ __CLASS__, 'render_portal_markup' ] );
         add_action( 'rest_api_init', [ __CLASS__, 'register_embed_endpoint' ] );
     }
@@ -54,15 +56,89 @@ class TB_Frontend {
             return $actions;
         }
 
+        $action = self::determine_listing_action( $listing_id );
+
+        if ( ! $action ) {
+            return $actions;
+        }
+
+        return self::add_action_after_duplicate( $actions, $action['key'], $action['config'] );
+    }
+
+    /**
+     * Render Trust Badge action markup for dashboard listing rows.
+     *
+     * @param object $listing Listing object from MyListing template.
+     */
+    public static function render_dashboard_action( $listing ) {
+        if ( ! is_object( $listing ) || ! method_exists( $listing, 'get_id' ) ) {
+            return;
+        }
+
+        static $rendered = [];
+
+        $listing_id = (int) $listing->get_id();
+
+        if ( ! current_user_can( 'edit_post', $listing_id ) ) {
+            return;
+        }
+
+        if ( isset( $rendered[ $listing_id ] ) ) {
+            return;
+        }
+
+        $rendered[ $listing_id ] = true;
+
+        $action = self::determine_listing_action( $listing_id );
+
+        if ( ! $action ) {
+            return;
+        }
+
+        $config = $action['config'];
+        $label  = isset( $config['label'] ) ? $config['label'] : '';
+        $icon   = ! empty( $config['icon'] ) ? sprintf( '<i class="%s"></i> ', esc_attr( $config['icon'] ) ) : '';
+        $attrs  = self::format_action_attributes( isset( $config['data'] ) ? $config['data'] : [] );
+        $attrs  = $attrs ? ' ' . $attrs : '';
+        $class  = sanitize_html_class( str_replace( 'tb_', 'tb-', $action['key'] ) );
+
+        printf(
+            '<li class="cts-listing-action-%1$s"><a href="#" class="tb-listing-action"%2$s>%3$s%4$s</a></li>',
+            esc_attr( $class ),
+            $attrs,
+            $icon,
+            esc_html( $label )
+        );
+    }
+
+    /**
+     * Determine the Trust Badge action configuration for a listing.
+     *
+     * @param int $listing_id Listing ID.
+     * @return array|null
+     */
+    private static function determine_listing_action( $listing_id ) {
+        $listing_id = (int) $listing_id;
+
+        if ( ! $listing_id ) {
+            return null;
+        }
+
         $request = TB_Request::get_for_listing( $listing_id );
 
         if ( ! $request ) {
-            return self::add_action_after_duplicate( $actions, 'tb_request', [
-                'label'  => __( 'Request Trust Badge', 'trust-badge' ),
-                'icon'   => 'la la-shield',
-                'action' => 'tbOpenRequest',
-                'data'   => [ 'listingId' => $listing_id ],
-            ] );
+            return [
+                'key'    => 'tb_request',
+                'config' => [
+                    'label' => __( 'Request Trust Badge', 'trust-badge' ),
+                    'icon'  => 'la la-shield',
+                    'action'=> 'tbOpenRequest',
+                    'data'  => [
+                        'tb-action'    => 'request',
+                        'listing-id'   => $listing_id,
+                    ],
+                ],
+            ];
         }
 
         $request_id = $request instanceof WP_Post ? $request->ID : (int) $request;
@@ -70,47 +146,90 @@ class TB_Frontend {
 
         if ( 'tb_approved' === $status ) {
             if ( TB_Request::is_active( $request_id ) ) {
-                $actions = self::add_action_after_duplicate( $actions, 'tb_copy', [
-                    'label'  => __( 'Copy Trust Badge', 'trust-badge' ),
-                    'icon'   => 'la la-copy',
-                    'action' => 'tbOpenEmbed',
-                    'data'   => [ 'requestId' => $request_id ],
-                ] );
-            } else {
-                $actions = self::add_action_after_duplicate( $actions, 'tb_renew', [
-                    'label'  => __( 'Renew Trust Badge', 'trust-badge' ),
-                    'icon'   => 'la la-sync',
-                    'action' => 'tbOpenRequest',
-                    'data'   => [
-                        'listingId' => $listing_id,
-                        'renew'     => true,
-                        'requestId' => $request_id,
+                return [
+                    'key'    => 'tb_copy',
+                    'config' => [
+                        'label' => __( 'Copy Trust Badge', 'trust-badge' ),
+                        'icon'  => 'la la-copy',
+                        'action'=> 'tbOpenEmbed',
+                        'data'  => [
+                            'tb-action'    => 'embed',
+                            'request-id'   => $request_id,
+                        ],
                     ],
-                ] );
+                ];
             }
-        } elseif ( 'tb_rejected' === $status ) {
-            $actions = self::add_action_after_duplicate( $actions, 'tb_update', [
-                'label'  => __( 'Update Trust Badge Request', 'trust-badge' ),
-                'icon'   => 'la la-edit',
-                'action' => 'tbOpenRequest',
-                'data'   => [
-                    'listingId' => $listing_id,
-                    'requestId' => $request_id,
+
+            return [
+                'key'    => 'tb_renew',
+                'config' => [
+                    'label' => __( 'Renew Trust Badge', 'trust-badge' ),
+                    'icon'  => 'la la-sync',
+                    'action'=> 'tbOpenRequest',
+                    'data'  => [
+                        'tb-action'    => 'request',
+                        'listing-id'   => $listing_id,
+                        'request-id'   => $request_id,
+                        'tb-renew'     => '1',
+                    ],
                 ],
-            ] );
-        } else {
-            $actions = self::add_action_after_duplicate( $actions, 'tb_view', [
-                'label'  => __( 'View Trust Badge Request', 'trust-badge' ),
-                'icon'   => 'la la-eye',
-                'action' => 'tbOpenRequest',
-                'data'   => [
-                    'listingId' => $listing_id,
-                    'requestId' => $request_id,
-                ],
-            ] );
+            ];
         }
 
-        return $actions;
+        if ( 'tb_rejected' === $status ) {
+            return [
+                'key'    => 'tb_update',
+                'config' => [
+                    'label' => __( 'Update Trust Badge Request', 'trust-badge' ),
+                    'icon'  => 'la la-edit',
+                    'action'=> 'tbOpenRequest',
+                    'data'  => [
+                        'tb-action'    => 'request',
+                        'listing-id'   => $listing_id,
+                        'request-id'   => $request_id,
+                    ],
+                ],
+            ];
+        }
+
+        return [
+            'key'    => 'tb_view',
+            'config' => [
+                'label' => __( 'View Trust Badge Request', 'trust-badge' ),
+                'icon'  => 'la la-eye',
+                'action'=> 'tbOpenRequest',
+                'data'  => [
+                    'tb-action'    => 'request',
+                    'listing-id'   => $listing_id,
+                    'request-id'   => $request_id,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Convert dataset into HTML attributes for action markup.
+     *
+     * @param array $data Key/value pairs.
+     * @return string
+     */
+    private static function format_action_attributes( array $data ) {
+        if ( empty( $data ) ) {
+            return '';
+        }
+
+        $attrs = [];
+
+        foreach ( $data as $key => $value ) {
+            if ( '' === $value || null === $value ) {
+                continue;
+            }
+
+            $attribute = 'data-' . preg_replace( '/[^a-z0-9_-]/', '', strtolower( (string) $key ) );
+            $attrs[]   = sprintf( '%s="%s"', esc_attr( $attribute ), esc_attr( $value ) );
+        }
+
+        return implode( ' ', $attrs );
     }
 
     /**

--- a/trust-badge/includes/class-tb-frontend.php
+++ b/trust-badge/includes/class-tb-frontend.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Frontend integration with MyListing dashboard.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Frontend {
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_filter( 'mylisting/listing_actions', [ __CLASS__, 'inject_listing_actions' ], 10, 2 );
+        add_action( 'wp_footer', [ __CLASS__, 'render_portal_markup' ] );
+        add_action( 'rest_api_init', [ __CLASS__, 'register_embed_endpoint' ] );
+    }
+
+    /**
+     * Enqueue frontend assets when user logged in.
+     */
+    public static function enqueue_assets() {
+        if ( ! is_user_logged_in() ) {
+            return;
+        }
+
+        $is_account = function_exists( 'is_account_page' ) ? is_account_page() : false;
+        if ( ! $is_account && ! is_page_template( 'templates/dashboard.php' ) && ! is_page( 'my-account' ) ) {
+            return;
+        }
+
+        wp_enqueue_style( 'tb-frontend', TB_PLUGIN_URL . 'assets/frontend.css', [], TB_PLUGIN_VER );
+        wp_enqueue_script( 'tb-frontend', TB_PLUGIN_URL . 'assets/frontend.js', [ 'jquery', 'wp-util', 'wp-i18n' ], TB_PLUGIN_VER, true );
+        wp_set_script_translations( 'tb-frontend', 'trust-badge', dirname( plugin_basename( TB_PLUGIN_FILE ) ) . '/languages' );
+        wp_enqueue_media();
+        wp_localize_script( 'tb-frontend', 'TBFrontend', [
+            'nonce'      => wp_create_nonce( 'wp_rest' ),
+            'restRoot'   => esc_url_raw( rest_url( TB_Rest::NAMESPACE ) ),
+            'copyLabel'  => __( 'Copy to clipboard', 'trust-badge' ),
+            'copiedLabel'=> __( 'Copied!', 'trust-badge' ),
+        ] );
+    }
+
+    /**
+     * Inject action buttons into MyListing listing cards.
+     */
+    public static function inject_listing_actions( $actions, $listing_id ) {
+        if ( ! current_user_can( 'edit_post', $listing_id ) ) {
+            return $actions;
+        }
+
+        $request = TB_Request::get_for_listing( $listing_id );
+
+        if ( ! $request ) {
+            return self::add_action_after_duplicate( $actions, 'tb_request', [
+                'label'  => __( 'Request Trust Badge', 'trust-badge' ),
+                'icon'   => 'la la-shield',
+                'action' => 'tbOpenRequest',
+                'data'   => [ 'listingId' => $listing_id ],
+            ] );
+        }
+
+        $request_id = $request instanceof WP_Post ? $request->ID : (int) $request;
+        $status     = get_post_status( $request_id );
+
+        if ( 'tb_approved' === $status ) {
+            if ( TB_Request::is_active( $request_id ) ) {
+                $actions = self::add_action_after_duplicate( $actions, 'tb_copy', [
+                    'label'  => __( 'Copy Trust Badge', 'trust-badge' ),
+                    'icon'   => 'la la-copy',
+                    'action' => 'tbOpenEmbed',
+                    'data'   => [ 'requestId' => $request_id ],
+                ] );
+            } else {
+                $actions = self::add_action_after_duplicate( $actions, 'tb_renew', [
+                    'label'  => __( 'Renew Trust Badge', 'trust-badge' ),
+                    'icon'   => 'la la-sync',
+                    'action' => 'tbOpenRequest',
+                    'data'   => [
+                        'listingId' => $listing_id,
+                        'renew'     => true,
+                        'requestId' => $request_id,
+                    ],
+                ] );
+            }
+        } elseif ( 'tb_rejected' === $status ) {
+            $actions = self::add_action_after_duplicate( $actions, 'tb_update', [
+                'label'  => __( 'Update Trust Badge Request', 'trust-badge' ),
+                'icon'   => 'la la-edit',
+                'action' => 'tbOpenRequest',
+                'data'   => [
+                    'listingId' => $listing_id,
+                    'requestId' => $request_id,
+                ],
+            ] );
+        } else {
+            $actions = self::add_action_after_duplicate( $actions, 'tb_view', [
+                'label'  => __( 'View Trust Badge Request', 'trust-badge' ),
+                'icon'   => 'la la-eye',
+                'action' => 'tbOpenRequest',
+                'data'   => [
+                    'listingId' => $listing_id,
+                    'requestId' => $request_id,
+                ],
+            ] );
+        }
+
+        return $actions;
+    }
+
+    /**
+     * Insert Trust Badge action after the Duplicate action if present.
+     *
+     * @param array  $actions   Existing actions.
+     * @param string $key       New action key.
+     * @param array  $config    Action configuration.
+     * @return array
+     */
+    private static function add_action_after_duplicate( array $actions, $key, array $config ) {
+        $anchors    = apply_filters(
+            'tb_trust_badge_action_anchor_keys',
+            [ 'duplicate', 'cts_duplicate', 'duplicate_listing', 'listing-duplicate', 'duplicate-listing' ]
+        );
+        $new_actions = [];
+        $inserted    = false;
+
+        foreach ( $actions as $action_key => $action ) {
+            $new_actions[ $action_key ] = $action;
+
+            if ( ! $inserted && in_array( $action_key, $anchors, true ) ) {
+                $new_actions[ $key ] = $config;
+                $inserted            = true;
+            }
+        }
+
+        if ( ! $inserted ) {
+            $new_actions[ $key ] = $config;
+        }
+
+        return $new_actions;
+    }
+
+    /**
+     * Output reusable modal containers in footer.
+     */
+    public static function render_portal_markup() {
+        if ( ! is_user_logged_in() ) {
+            return;
+        }
+
+        echo '<div id="tb-modal-root" class="tb-hidden" aria-hidden="true"></div>';
+    }
+
+    /**
+     * Register embed script endpoint (iframe fallback).
+     */
+    public static function register_embed_endpoint() {
+        register_rest_route( TB_Rest::NAMESPACE, '/embed/(?P<token>[A-Za-z0-9_-]{20,})', [
+            'methods'             => WP_REST_Server::READABLE,
+            'permission_callback' => '__return_true',
+            'callback'            => [ __CLASS__, 'serve_embed_markup' ],
+        ] );
+    }
+
+    /**
+     * Return iframe markup.
+     */
+    public static function serve_embed_markup( WP_REST_Request $request ) {
+        $response = TB_Rest::badge_public( $request );
+        $data     = $response instanceof WP_REST_Response ? $response->get_data() : $response;
+
+        if ( empty( $data['valid'] ) ) {
+            return rest_ensure_response( '<!-- invalid trust badge -->' );
+        }
+
+        return rest_ensure_response( $data['badge'] );
+    }
+}

--- a/trust-badge/includes/class-tb-frontend.php
+++ b/trust-badge/includes/class-tb-frontend.php
@@ -45,6 +45,8 @@ class TB_Frontend {
             'restRoot'   => esc_url_raw( rest_url( TB_Rest::NAMESPACE ) ),
             'copyLabel'  => __( 'Copy to clipboard', 'trust-badge' ),
             'copiedLabel'=> __( 'Copied!', 'trust-badge' ),
+            'embedScript'=> esc_url_raw( TB_PLUGIN_URL . 'assets/embed.js' ),
+            'iframeBase' => esc_url_raw( rest_url( TB_Rest::NAMESPACE . '/embed/' ) ),
         ] );
     }
 

--- a/trust-badge/includes/class-tb-frontend.php
+++ b/trust-badge/includes/class-tb-frontend.php
@@ -171,13 +171,20 @@ class TB_Frontend {
      * Return iframe markup.
      */
     public static function serve_embed_markup( WP_REST_Request $request ) {
-        $response = TB_Rest::badge_public( $request );
-        $data     = $response instanceof WP_REST_Response ? $response->get_data() : $response;
+        $response    = TB_Rest::badge_public( $request );
+        $data        = $response instanceof WP_REST_Response ? $response->get_data() : $response;
+        $status_code = $response instanceof WP_REST_Response ? $response->get_status() : 200;
 
-        if ( empty( $data['valid'] ) ) {
-            return rest_ensure_response( '<!-- invalid trust badge -->' );
+        $headers = [ 'Content-Type' => 'text/html; charset=' . get_option( 'blog_charset', 'utf-8' ) ];
+
+        if ( is_wp_error( $response ) ) {
+            return new WP_REST_Response( '<!-- trust badge error -->', 400, $headers );
         }
 
-        return rest_ensure_response( $data['badge'] );
+        if ( empty( $data['valid'] ) || empty( $data['badge'] ) ) {
+            return new WP_REST_Response( '<!-- invalid trust badge -->', 410, $headers );
+        }
+
+        return new WP_REST_Response( $data['badge'], $status_code, $headers );
     }
 }

--- a/trust-badge/includes/class-tb-installer.php
+++ b/trust-badge/includes/class-tb-installer.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Activation/deactivation tasks.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Installer {
+
+    /**
+     * Run on activation.
+     */
+    public static function activate() {
+        TB_CPT::register_post_type();
+        TB_CPT::register_statuses();
+        flush_rewrite_rules();
+        TB_Cron::activate();
+    }
+
+    /**
+     * Run on deactivation.
+     */
+    public static function deactivate() {
+        TB_Cron::deactivate();
+        flush_rewrite_rules();
+    }
+}

--- a/trust-badge/includes/class-tb-plugin.php
+++ b/trust-badge/includes/class-tb-plugin.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Plugin {
+
+    /**
+     * Initialise plugin components.
+     */
+    public static function init() {
+        load_plugin_textdomain( 'trust-badge', false, dirname( plugin_basename( TB_PLUGIN_FILE ) ) . '/languages/' );
+
+        TB_Settings::init();
+        TB_CPT::init();
+        TB_Request::init();
+        TB_Rest::init();
+        TB_Admin::init();
+        TB_Frontend::init();
+        TB_Badge::init();
+        TB_Cron::init();
+    }
+}

--- a/trust-badge/includes/class-tb-request.php
+++ b/trust-badge/includes/class-tb-request.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Utilities for working with trust badge requests.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Request {
+
+    const META_CONTACT_NAME  = '_tb_contact_name';
+    const META_CONTACT_EMAIL = '_tb_contact_email';
+    const META_CONTACT_PHONE = '_tb_contact_phone';
+    const META_DOCUMENTS     = '_tb_documents';
+    const META_EXPIRES_AT    = '_tb_expires_at';
+    const META_DECISION_NOTE = '_tb_decision_note';
+    const META_TOKEN         = '_tb_token';
+    const META_VERSION       = '_tb_version';
+    const META_AUDIT_LOG     = '_tb_audit_log';
+
+    /**
+     * Hook registration.
+     */
+    public static function init() {
+        add_action( 'before_delete_post', [ __CLASS__, 'maybe_cleanup_on_delete' ] );
+    }
+
+    /**
+     * Get existing request for listing.
+     *
+     * @param int $listing_id Listing ID.
+     * @return WP_Post|null
+     */
+    public static function get_for_listing( $listing_id ) {
+        $query = new WP_Query( [
+            'post_type'      => TB_CPT::POST_TYPE,
+            'post_status'    => [ 'tb_pending', 'tb_approved', 'tb_rejected', 'tb_expired' ],
+            'post_parent'    => $listing_id,
+            'posts_per_page' => 1,
+            'orderby'        => 'ID',
+            'order'          => 'DESC',
+            'no_found_rows'  => true,
+            'fields'         => 'all',
+        ] );
+
+        return $query->posts ? $query->posts[0] : null;
+    }
+
+    /**
+     * Determine if request is active (approved and not expired).
+     *
+     * @param int $request_id Request ID.
+     * @return bool
+     */
+    public static function is_active( $request_id ) {
+        $status = get_post_status( $request_id );
+        if ( 'tb_approved' !== $status ) {
+            return false;
+        }
+
+        $expires = (int) get_post_meta( $request_id, self::META_EXPIRES_AT, true );
+
+        return $expires && $expires > time();
+    }
+
+    /**
+     * Ensure token exists for request.
+     *
+     * @param int $request_id Request ID.
+     * @return string
+     */
+    public static function ensure_token( $request_id ) {
+        $token = get_post_meta( $request_id, self::META_TOKEN, true );
+        if ( ! $token ) {
+            $token = wp_generate_password( 48, false, false );
+            update_post_meta( $request_id, self::META_TOKEN, $token );
+        }
+
+        return $token;
+    }
+
+    /**
+     * Append audit log entry.
+     *
+     * @param int    $request_id Request ID.
+     * @param string $action Action keyword.
+     * @param string $note Optional note.
+     */
+    public static function log_action( $request_id, $action, $note = '' ) {
+        $log = get_post_meta( $request_id, self::META_AUDIT_LOG, true );
+        if ( empty( $log ) ) {
+            $log = [];
+        }
+
+        $log[] = [
+            'time'   => current_time( 'mysql', true ),
+            'actor'  => get_current_user_id(),
+            'action' => sanitize_key( $action ),
+            'note'   => sanitize_text_field( $note ),
+        ];
+
+        update_post_meta( $request_id, self::META_AUDIT_LOG, $log );
+    }
+
+    /**
+     * Return audit log entries.
+     *
+     * @param int $request_id Request ID.
+     * @return array
+     */
+    public static function get_audit_log( $request_id ) {
+        $log = get_post_meta( $request_id, self::META_AUDIT_LOG, true );
+        return is_array( $log ) ? $log : [];
+    }
+
+    /**
+     * Delete related documents when request deleted.
+     *
+     * @param int $post_id Post ID.
+     */
+    public static function maybe_cleanup_on_delete( $post_id ) {
+        $post = get_post( $post_id );
+        if ( ! $post || TB_CPT::POST_TYPE !== $post->post_type ) {
+            return;
+        }
+
+        $documents = get_post_meta( $post_id, self::META_DOCUMENTS, true );
+        if ( is_array( $documents ) ) {
+            foreach ( $documents as $attachment_id ) {
+                if ( current_user_can( 'delete_post', $attachment_id ) ) {
+                    wp_delete_attachment( $attachment_id, true );
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if current user may manage request.
+     *
+     * @param WP_Post $request Request object.
+     * @return bool
+     */
+    public static function current_user_can_manage( $request ) {
+        if ( ! $request instanceof WP_Post ) {
+            $request = get_post( $request );
+        }
+
+        if ( ! $request ) {
+            return false;
+        }
+
+        if ( current_user_can( 'manage_options' ) || current_user_can( 'manage_trust_badges' ) ) {
+            return true;
+        }
+
+        $owner_id   = (int) $request->post_author;
+        $listing_id = (int) $request->post_parent;
+
+        if ( $owner_id === get_current_user_id() ) {
+            return true;
+        }
+
+        if ( $listing_id && current_user_can( 'edit_post', $listing_id ) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Update request meta safely.
+     *
+     * @param int   $request_id Request ID.
+     * @param array $meta Meta values.
+     */
+    public static function update_meta( $request_id, array $meta ) {
+        foreach ( $meta as $key => $value ) {
+            update_post_meta( $request_id, $key, $value );
+        }
+    }
+
+    /**
+     * Calculate default expiry timestamp.
+     *
+     * @return int
+     */
+    public static function calculate_default_expiry() {
+        $settings = TB_Settings::get_settings();
+        $days     = max( 1, absint( $settings['validity_days'] ) );
+
+        return time() + DAY_IN_SECONDS * $days;
+    }
+}

--- a/trust-badge/includes/class-tb-rest.php
+++ b/trust-badge/includes/class-tb-rest.php
@@ -1,0 +1,458 @@
+<?php
+/**
+ * REST API endpoints for Trust Badge.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Rest {
+
+    const NAMESPACE = 'trustbadge/v1';
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+    }
+
+    /**
+     * Register all REST routes.
+     */
+    public static function register_routes() {
+        register_rest_route( self::NAMESPACE, '/requests', [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'permission_callback' => [ __CLASS__, 'create_request_permissions' ],
+            'callback'            => [ __CLASS__, 'create_request' ],
+            'args'                => self::get_request_args(),
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/requests', [
+            'methods'             => WP_REST_Server::READABLE,
+            'permission_callback' => [ __CLASS__, 'list_requests_permissions' ],
+            'callback'            => [ __CLASS__, 'list_requests' ],
+            'args'                => [
+                'status'  => [ 'type' => 'string', 'required' => false ],
+                'owner'   => [ 'type' => 'integer', 'required' => false ],
+                'listing' => [ 'type' => 'integer', 'required' => false ],
+                'page'    => [ 'type' => 'integer', 'required' => false, 'default' => 1 ],
+            ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/requests/(?P<id>\d+)', [
+            'methods'             => WP_REST_Server::READABLE,
+            'permission_callback' => [ __CLASS__, 'view_request_permissions' ],
+            'callback'            => [ __CLASS__, 'view_request' ],
+            'args'                => [ 'id' => [ 'type' => 'integer', 'required' => true ] ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/requests/(?P<id>\d+)/approve', [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'permission_callback' => [ __CLASS__, 'admin_permissions' ],
+            'callback'            => [ __CLASS__, 'approve_request' ],
+            'args'                => [
+                'expires_at' => [ 'type' => 'string', 'required' => true ],
+                'note'       => [ 'type' => 'string', 'required' => false ],
+            ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/requests/(?P<id>\d+)/reject', [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'permission_callback' => [ __CLASS__, 'admin_permissions' ],
+            'callback'            => [ __CLASS__, 'reject_request' ],
+            'args'                => [
+                'note' => [ 'type' => 'string', 'required' => true ],
+            ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/requests/(?P<id>\d+)/extend', [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'permission_callback' => [ __CLASS__, 'admin_permissions' ],
+            'callback'            => [ __CLASS__, 'extend_request' ],
+            'args'                => [
+                'expires_at' => [ 'type' => 'string', 'required' => true ],
+            ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/badge/(?P<token>[A-Za-z0-9_-]{20,})', [
+            'methods'             => WP_REST_Server::READABLE,
+            'permission_callback' => '__return_true',
+            'callback'            => [ __CLASS__, 'badge_public' ],
+        ] );
+    }
+
+    /**
+     * Permission check for creating request.
+     */
+    public static function create_request_permissions( WP_REST_Request $request ) {
+        $listing_id = (int) $request['listing_id'];
+        if ( ! $listing_id ) {
+            return false;
+        }
+
+        return is_user_logged_in() && current_user_can( 'edit_post', $listing_id );
+    }
+
+    /**
+     * Permission check for listing requests (admin).
+     */
+    public static function list_requests_permissions() {
+        return current_user_can( 'manage_options' ) || current_user_can( 'manage_trust_badges' );
+    }
+
+    /**
+     * Permission check for viewing individual request.
+     */
+    public static function view_request_permissions( WP_REST_Request $request ) {
+        $request_post = get_post( (int) $request['id'] );
+        if ( ! $request_post || TB_CPT::POST_TYPE !== $request_post->post_type ) {
+            return new WP_Error( 'tb_not_found', __( 'Request not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        if ( TB_Request::current_user_can_manage( $request_post ) ) {
+            return true;
+        }
+
+        return new WP_Error( 'tb_forbidden', __( 'You do not have permission to view this request.', 'trust-badge' ), [ 'status' => 403 ] );
+    }
+
+    /**
+     * Permission check for admin-only actions.
+     */
+    public static function admin_permissions() {
+        return self::list_requests_permissions();
+    }
+
+    /**
+     * Create or update a request.
+     */
+    public static function create_request( WP_REST_Request $request ) {
+        $listing_id = (int) $request['listing_id'];
+        $listing    = get_post( $listing_id );
+        if ( ! $listing ) {
+            return new WP_Error( 'tb_invalid_listing', __( 'Listing not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        $contact_name  = sanitize_text_field( $request['contact_name'] );
+        $contact_email = sanitize_email( $request['contact_email'] );
+        $contact_phone = sanitize_text_field( $request['contact_phone'] );
+
+        if ( empty( $contact_name ) || empty( $contact_email ) ) {
+            return new WP_Error( 'tb_missing_fields', __( 'Contact name and email are required.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        if ( ! is_email( $contact_email ) ) {
+            return new WP_Error( 'tb_invalid_email', __( 'Invalid email address.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        $documents = array_filter( array_map( 'absint', (array) $request['documents'] ) );
+
+        foreach ( $documents as $attachment_id ) {
+            if ( ! self::validate_document_attachment( $attachment_id ) ) {
+                return new WP_Error( 'tb_invalid_document', __( 'One or more documents are invalid.', 'trust-badge' ), [ 'status' => 400 ] );
+            }
+        }
+
+        $existing = TB_Request::get_for_listing( $listing_id );
+
+        $postarr = [
+            'post_type'   => TB_CPT::POST_TYPE,
+            'post_title'  => sprintf( __( 'Trust badge request for %s', 'trust-badge' ), $listing->post_title ),
+            'post_status' => 'tb_pending',
+            'post_parent' => $listing_id,
+            'post_author' => get_current_user_id(),
+        ];
+
+        if ( $existing ) {
+            $postarr['ID'] = $existing->ID;
+        }
+
+        $request_id = wp_insert_post( wp_slash( $postarr ), true );
+
+        if ( is_wp_error( $request_id ) ) {
+            return $request_id;
+        }
+
+        TB_Request::ensure_token( $request_id );
+        TB_Request::update_meta( $request_id, [
+            TB_Request::META_CONTACT_NAME  => $contact_name,
+            TB_Request::META_CONTACT_EMAIL => $contact_email,
+            TB_Request::META_CONTACT_PHONE => $contact_phone,
+            TB_Request::META_DOCUMENTS     => $documents,
+            TB_Request::META_VERSION       => 1,
+        ] );
+
+        TB_Request::log_action( $request_id, 'submitted' );
+
+        do_action( 'tb_request_submitted', $request_id, $listing_id );
+
+        return self::format_request_response( get_post( $request_id ) );
+    }
+
+    /**
+     * Provide argument definitions for create/update route.
+     *
+     * @return array
+     */
+    protected static function get_request_args() {
+        return [
+            'listing_id'    => [ 'type' => 'integer', 'required' => true ],
+            'contact_name'  => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_text_field' ],
+            'contact_email' => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_email' ],
+            'contact_phone' => [ 'type' => 'string', 'required' => false, 'sanitize_callback' => 'sanitize_text_field' ],
+            'documents'     => [ 'type' => 'array', 'required' => false ],
+        ];
+    }
+
+    /**
+     * Format request details for response.
+     */
+    protected static function format_request_response( $request_post ) {
+        if ( ! $request_post instanceof WP_Post ) {
+            $request_post = get_post( $request_post );
+        }
+
+        if ( ! $request_post ) {
+            return null;
+        }
+
+        $expires = (int) get_post_meta( $request_post->ID, TB_Request::META_EXPIRES_AT, true );
+
+        return [
+            'id'           => (int) $request_post->ID,
+            'listing_id'   => (int) $request_post->post_parent,
+            'status'       => get_post_status( $request_post ),
+            'submitted_at' => get_post_time( 'c', false, $request_post ),
+            'expires_at'   => $expires ? gmdate( 'c', $expires ) : null,
+            'contact'      => [
+                'name'  => get_post_meta( $request_post->ID, TB_Request::META_CONTACT_NAME, true ),
+                'email' => get_post_meta( $request_post->ID, TB_Request::META_CONTACT_EMAIL, true ),
+                'phone' => get_post_meta( $request_post->ID, TB_Request::META_CONTACT_PHONE, true ),
+            ],
+            'documents'    => array_map( 'intval', (array) get_post_meta( $request_post->ID, TB_Request::META_DOCUMENTS, true ) ),
+            'token'        => get_post_meta( $request_post->ID, TB_Request::META_TOKEN, true ),
+        ];
+    }
+
+    /**
+     * List requests for admin usage.
+     */
+    public static function list_requests( WP_REST_Request $request ) {
+        $args = [
+            'post_type'      => TB_CPT::POST_TYPE,
+            'post_status'    => [ 'tb_pending', 'tb_approved', 'tb_rejected', 'tb_expired' ],
+            'posts_per_page' => 20,
+            'paged'          => max( 1, (int) $request['page'] ),
+        ];
+
+        if ( $request['status'] ) {
+            $args['post_status'] = array_map( 'sanitize_key', (array) $request['status'] );
+        }
+
+        if ( $request['owner'] ) {
+            $args['author'] = (int) $request['owner'];
+        }
+
+        if ( $request['listing'] ) {
+            $args['post_parent'] = (int) $request['listing'];
+        }
+
+        $query = new WP_Query( $args );
+        $items = array_map( [ __CLASS__, 'format_request_response' ], $query->posts );
+
+        return [
+            'items' => $items,
+            'total' => (int) $query->found_posts,
+            'pages' => (int) $query->max_num_pages,
+        ];
+    }
+
+    /**
+     * View request details.
+     */
+    public static function view_request( WP_REST_Request $request ) {
+        $post = get_post( (int) $request['id'] );
+        if ( ! $post ) {
+            return new WP_Error( 'tb_not_found', __( 'Request not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        return self::format_request_response( $post );
+    }
+
+    /**
+     * Approve a request.
+     */
+    public static function approve_request( WP_REST_Request $request ) {
+        $request_post = get_post( (int) $request['id'] );
+        if ( ! $request_post ) {
+            return new WP_Error( 'tb_not_found', __( 'Request not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        $expires_at = strtotime( $request['expires_at'] );
+        if ( ! $expires_at ) {
+            return new WP_Error( 'tb_invalid_date', __( 'Invalid expiry date.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        wp_update_post( [ 'ID' => $request_post->ID, 'post_status' => 'tb_approved' ] );
+
+        TB_Request::update_meta( $request_post->ID, [ TB_Request::META_EXPIRES_AT => $expires_at ] );
+        if ( isset( $request['note'] ) ) {
+            TB_Request::update_meta( $request_post->ID, [ TB_Request::META_DECISION_NOTE => sanitize_textarea_field( $request['note'] ) ] );
+        }
+
+        TB_Request::log_action( $request_post->ID, 'approved', $request['note'] ?? '' );
+
+        do_action( 'tb_request_approved', $request_post->ID );
+
+        return self::format_request_response( $request_post );
+    }
+
+    /**
+     * Reject request.
+     */
+    public static function reject_request( WP_REST_Request $request ) {
+        $request_post = get_post( (int) $request['id'] );
+        if ( ! $request_post ) {
+            return new WP_Error( 'tb_not_found', __( 'Request not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        $note = sanitize_textarea_field( $request['note'] );
+        if ( empty( $note ) ) {
+            return new WP_Error( 'tb_missing_note', __( 'A rejection note is required.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        wp_update_post( [ 'ID' => $request_post->ID, 'post_status' => 'tb_rejected' ] );
+        TB_Request::update_meta( $request_post->ID, [ TB_Request::META_DECISION_NOTE => $note ] );
+        TB_Request::log_action( $request_post->ID, 'rejected', $note );
+
+        do_action( 'tb_request_rejected', $request_post->ID );
+
+        return self::format_request_response( $request_post );
+    }
+
+    /**
+     * Extend expiry date.
+     */
+    public static function extend_request( WP_REST_Request $request ) {
+        $request_post = get_post( (int) $request['id'] );
+        if ( ! $request_post ) {
+            return new WP_Error( 'tb_not_found', __( 'Request not found.', 'trust-badge' ), [ 'status' => 404 ] );
+        }
+
+        $expires_at = strtotime( $request['expires_at'] );
+        if ( ! $expires_at ) {
+            return new WP_Error( 'tb_invalid_date', __( 'Invalid expiry date.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        if ( 'tb_approved' !== get_post_status( $request_post ) ) {
+            return new WP_Error( 'tb_invalid_state', __( 'Only approved requests may be extended.', 'trust-badge' ), [ 'status' => 400 ] );
+        }
+
+        TB_Request::update_meta( $request_post->ID, [ TB_Request::META_EXPIRES_AT => $expires_at ] );
+        TB_Request::log_action( $request_post->ID, 'extended' );
+
+        do_action( 'tb_request_extended', $request_post->ID );
+
+        return self::format_request_response( $request_post );
+    }
+
+    /**
+     * Public badge endpoint.
+     */
+    public static function badge_public( WP_REST_Request $request ) {
+        $token = sanitize_text_field( $request['token'] );
+        $post  = self::get_request_by_token( $token );
+        if ( ! $post ) {
+            return rest_ensure_response( [ 'valid' => false ] );
+        }
+
+        $expires = (int) get_post_meta( $post->ID, TB_Request::META_EXPIRES_AT, true );
+        $status  = get_post_status( $post );
+
+        $valid = ( 'tb_approved' === $status ) && $expires && $expires > time();
+
+        $listing_id = (int) $post->post_parent;
+        $listing    = $listing_id ? get_post( $listing_id ) : null;
+
+        $settings = TB_Settings::get_settings();
+
+        $badge_html = TB_Badge::generate_markup( [
+            'listing'     => $listing,
+            'expires_at'  => $expires,
+            'valid'       => $valid,
+            'accent'      => $settings['accent_color'],
+            'show_expiry' => ! empty( $settings['show_expiry'] ),
+            'link'        => $settings['link_behavior'],
+        ] );
+
+        return rest_ensure_response( [
+            'valid'       => $valid,
+            'expires_at'  => $expires ? gmdate( 'c', $expires ) : null,
+            'listing_id'  => $listing_id,
+            'badge'       => $badge_html,
+            'listing_name'=> $listing ? $listing->post_title : '',
+        ] );
+    }
+
+    /**
+     * Get request post by token.
+     *
+     * @param string $token Token.
+     * @return WP_Post|null
+     */
+    protected static function get_request_by_token( $token ) {
+        global $wpdb;
+
+        $post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1", TB_Request::META_TOKEN, $token ) );
+
+        if ( ! $post_id ) {
+            return null;
+        }
+
+        $post = get_post( (int) $post_id );
+        if ( ! $post || TB_CPT::POST_TYPE !== $post->post_type ) {
+            return null;
+        }
+
+        return $post;
+    }
+
+    /**
+     * Ensure attachment is valid document.
+     *
+     * @param int $attachment_id Attachment ID.
+     * @return bool
+     */
+    protected static function validate_document_attachment( $attachment_id ) {
+        $attachment = get_post( $attachment_id );
+        if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+            return false;
+        }
+
+        if ( (int) $attachment->post_author !== get_current_user_id() && ! current_user_can( 'manage_options' ) ) {
+            return false;
+        }
+
+        $file = get_attached_file( $attachment_id );
+        if ( ! $file || ! file_exists( $file ) ) {
+            return false;
+        }
+
+        $settings = TB_Settings::get_settings();
+        $filetype = wp_check_filetype( $file );
+
+        if ( ! in_array( $filetype['type'], (array) $settings['allowed_mimes'], true ) ) {
+            return false;
+        }
+
+        if ( filesize( $file ) > (float) $settings['max_file_size'] ) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/trust-badge/includes/class-tb-settings.php
+++ b/trust-badge/includes/class-tb-settings.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Settings API wrapper.
+ *
+ * @package TrustBadge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class TB_Settings {
+
+    const OPTION_KEY = 'tb_settings';
+
+    /**
+     * Default settings values.
+     *
+     * @return array
+     */
+    public static function defaults() {
+        return [
+            'validity_days'   => 365,
+            'reminder_days'   => 14,
+            'allowed_mimes'   => [ 'application/pdf', 'image/jpeg', 'image/png' ],
+            'max_file_size'   => 5 * MB_IN_BYTES,
+            'badge_style'     => 'classic',
+            'accent_color'    => '#1e73be',
+            'show_expiry'     => true,
+            'link_behavior'   => 'listing',
+        ];
+    }
+
+    /**
+     * Hook registration.
+     */
+    public static function init() {
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public static function register_settings() {
+        register_setting( 'tb_settings', self::OPTION_KEY, [ __CLASS__, 'sanitize' ] );
+
+        add_settings_section(
+            'tb_general',
+            __( 'General Settings', 'trust-badge' ),
+            '__return_false',
+            'tb_settings'
+        );
+
+        add_settings_field(
+            'validity_days',
+            __( 'Default Validity (days)', 'trust-badge' ),
+            [ __CLASS__, 'field_number' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'validity_days', 'min' => 1 ]
+        );
+
+        add_settings_field(
+            'reminder_days',
+            __( 'Reminder before expiry (days)', 'trust-badge' ),
+            [ __CLASS__, 'field_number' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'reminder_days', 'min' => 0 ]
+        );
+
+        add_settings_field(
+            'allowed_mimes',
+            __( 'Allowed MIME types', 'trust-badge' ),
+            [ __CLASS__, 'field_text' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'allowed_mimes', 'description' => __( 'Comma-separated list.', 'trust-badge' ) ]
+        );
+
+        add_settings_field(
+            'max_file_size',
+            __( 'Maximum file size (MB)', 'trust-badge' ),
+            [ __CLASS__, 'field_number' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'max_file_size', 'min' => 1, 'step' => 0.1 ]
+        );
+
+        add_settings_field(
+            'accent_color',
+            __( 'Badge accent color', 'trust-badge' ),
+            [ __CLASS__, 'field_color' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'accent_color' ]
+        );
+
+        add_settings_field(
+            'show_expiry',
+            __( 'Display expiry date on badge', 'trust-badge' ),
+            [ __CLASS__, 'field_checkbox' ],
+            'tb_settings',
+            'tb_general',
+            [ 'key' => 'show_expiry' ]
+        );
+
+        add_settings_field(
+            'link_behavior',
+            __( 'Badge link behaviour', 'trust-badge' ),
+            [ __CLASS__, 'field_select_link' ],
+            'tb_settings',
+            'tb_general',
+            []
+        );
+    }
+
+    /**
+     * Retrieve settings merged with defaults.
+     *
+     * @return array
+     */
+    public static function get_settings() {
+        $settings = get_option( self::OPTION_KEY, [] );
+
+        return wp_parse_args( $settings, self::defaults() );
+    }
+
+    /**
+     * Sanitize settings values.
+     *
+     * @param array $value Incoming value.
+     * @return array
+     */
+    public static function sanitize( $value ) {
+        $defaults = self::defaults();
+        $value    = (array) $value;
+
+        $sanitized = [];
+        $sanitized['validity_days'] = max( 1, absint( $value['validity_days'] ?? $defaults['validity_days'] ) );
+        $sanitized['reminder_days'] = max( 0, absint( $value['reminder_days'] ?? $defaults['reminder_days'] ) );
+
+        $mimes = $value['allowed_mimes'] ?? implode( ',', $defaults['allowed_mimes'] );
+        if ( is_array( $mimes ) ) {
+            $mimes = implode( ',', $mimes );
+        }
+        $mimes = array_filter( array_map( 'trim', explode( ',', strtolower( $mimes ) ) ) );
+        $sanitized['allowed_mimes'] = $mimes;
+
+        $max_size = isset( $value['max_file_size'] ) ? (float) $value['max_file_size'] : ( $defaults['max_file_size'] / MB_IN_BYTES );
+        $sanitized['max_file_size'] = max( 0.1, $max_size ) * MB_IN_BYTES;
+
+        $sanitized['badge_style']  = in_array( $value['badge_style'] ?? $defaults['badge_style'], [ 'classic', 'minimal' ], true ) ? $value['badge_style'] : $defaults['badge_style'];
+        $sanitized['accent_color'] = sanitize_hex_color( $value['accent_color'] ?? $defaults['accent_color'] ) ?: $defaults['accent_color'];
+        $sanitized['show_expiry']  = ! empty( $value['show_expiry'] );
+        $sanitized['link_behavior'] = in_array( $value['link_behavior'] ?? $defaults['link_behavior'], [ 'listing', 'issuer', 'none' ], true ) ? $value['link_behavior'] : $defaults['link_behavior'];
+
+        return $sanitized;
+    }
+
+    /**
+     * Render number input field.
+     *
+     * @param array $args Field args.
+     */
+    public static function field_number( $args ) {
+        $settings = self::get_settings();
+        $key      = $args['key'];
+        $value    = $settings[ $key ] ?? '';
+        $min      = $args['min'] ?? '';
+        $step     = $args['step'] ?? 1;
+
+        if ( 'max_file_size' === $key ) {
+            $value = $value / MB_IN_BYTES;
+        }
+
+        printf(
+            '<input type="number" name="%1$s[%2$s]" value="%3$s" min="%4$s" step="%5$s" class="small-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $key ),
+            esc_attr( $value ),
+            esc_attr( $min ),
+            esc_attr( $step )
+        );
+
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Render text input field.
+     */
+    public static function field_text( $args ) {
+        $settings = self::get_settings();
+        $key      = $args['key'];
+        $value    = $settings[ $key ] ?? '';
+
+        if ( is_array( $value ) ) {
+            $value = implode( ',', $value );
+        }
+
+        printf(
+            '<input type="text" name="%1$s[%2$s]" value="%3$s" class="regular-text" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $key ),
+            esc_attr( $value )
+        );
+
+        if ( ! empty( $args['description'] ) ) {
+            printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+        }
+    }
+
+    /**
+     * Render checkbox field.
+     */
+    public static function field_checkbox( $args ) {
+        $settings = self::get_settings();
+        $key      = $args['key'];
+        $value    = ! empty( $settings[ $key ] );
+
+        printf(
+            '<label><input type="checkbox" name="%1$s[%2$s]" value="1" %3$s/> %4$s</label>',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $key ),
+            checked( $value, true, false ),
+            esc_html__( 'Enable', 'trust-badge' )
+        );
+    }
+
+    /**
+     * Render select field for link behaviour.
+     */
+    public static function field_select_link() {
+        $settings = self::get_settings();
+        $value    = $settings['link_behavior'] ?? 'listing';
+
+        $options = [
+            'listing' => __( 'Link to listing', 'trust-badge' ),
+            'issuer'  => __( 'Link to issuer site', 'trust-badge' ),
+            'none'    => __( 'No link', 'trust-badge' ),
+        ];
+
+        printf( '<select name="%1$s[link_behavior]">', esc_attr( self::OPTION_KEY ) );
+        foreach ( $options as $key => $label ) {
+            printf( '<option value="%1$s" %2$s>%3$s</option>', esc_attr( $key ), selected( $value, $key, false ), esc_html( $label ) );
+        }
+        echo '</select>';
+    }
+
+    /**
+     * Render color field.
+     */
+    public static function field_color( $args ) {
+        $settings = self::get_settings();
+        $key      = $args['key'];
+        $value    = $settings[ $key ] ?? '#1e73be';
+
+        printf(
+            '<input type="text" class="tb-color-field" name="%1$s[%2$s]" value="%3$s" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $key ),
+            esc_attr( $value )
+        );
+    }
+}

--- a/trust-badge/trust-badge.php
+++ b/trust-badge/trust-badge.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name: Trust Badge for MyListing
+ * Description: Request/approve dynamic trust badges for listings.
+ * Version: 0.1.0
+ * Author: Trust Badge Team
+ * Text Domain: trust-badge
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'TB_PLUGIN_VER', '0.1.0' );
+define( 'TB_PLUGIN_FILE', __FILE__ );
+define( 'TB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'TB_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+require_once TB_PLUGIN_DIR . 'includes/class-tb-autoloader.php';
+TB_Autoloader::init();
+
+add_action( 'plugins_loaded', [ 'TB_Plugin', 'init' ] );
+
+register_activation_hook( __FILE__, [ 'TB_Installer', 'activate' ] );
+register_deactivation_hook( __FILE__, [ 'TB_Installer', 'deactivate' ] );


### PR DESCRIPTION
## Summary
- add a Trust Badge plugin skeleton for MyListing that registers the `trust_badge_request` CPT, custom statuses, cron expiry and audit trail helpers
- expose REST endpoints, frontend dashboard integrations, admin review screens and settings management to support the end-to-end badge workflow
- provide dynamic embed rendering assets, iframe/script endpoints and a default badge design with localisation-ready strings
- ensure Trust Badge dashboard actions are injected immediately after the Duplicate action for consistent button ordering

## Testing
- find trust-badge -name "*.php" -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68d5306a049083309f768f134d729533